### PR TITLE
Use SHA1PRNG SecureRandom

### DIFF
--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleClaimOperator.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleClaimOperator.java
@@ -31,7 +31,7 @@ public final class ModuleClaimOperator extends Module {
 
     static {
         try {
-            rng = SecureRandom.getInstanceStrong();
+            rng = SecureRandom.getInstance("SHA1PRNG");
         } catch (NoSuchAlgorithmException e) {
             Logger.error(e);
         }
@@ -87,7 +87,7 @@ public final class ModuleClaimOperator extends Module {
     private String generateRandomString() {
         StringBuilder ret = new StringBuilder();
         String[] validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890".split("");
-        while (ret.length() < 15) {
+        while (ret.length() < 80) {
             ret.append(validChars[rng.nextInt(validChars.length)]);
         }
         return ret.toString();


### PR DESCRIPTION
# Changelist

- As detailed [here](https://stackoverflow.com/questions/137212/how-to-solve-slow-java-securerandom), the default SecureRandom provider for Linux systems can be very slow (15 minutes for 15 characters on my system, possibly depending on user keyboard/mouse input, and with no progress indicator whatsoever). This did not make the bot unresponsive, but strongly delays its generation of a random key. The previous link to an SO post suggests using the SHA1PRNG algorithm, which is a lot faster (near instantaneous). This PR uses the SHA1PRNG algorithm, which is common in desktop Java implementations, and bumps up the key length to 80 characters, to (although somewhat poorly) compensate for SHA1PRNG's [less secure nature](https://stackoverflow.com/questions/27622625/securerandom-with-nativeprng-vs-sha1prng). 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adds or revises project documentation)

## Local configuration:
- OS: Linux
- JDK: OpenJDK 11.0.4+11
