### PR TITLE
Heavy refactoring and documentation in ModuleHelp

### DIFF
--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
@@ -33,51 +33,6 @@ public final class ModuleHelp extends Module {
         }
     }
 
-
-    /**
-     * Sends a message with a formatted embed enumerating all the commands in their respective `CommandType`.
-     *
-     * @param ctx The `CommandContext` to publish on.
-     */
-    private void fullCommandList(@NotNull CommandContext ctx) {
-
-        // Build and send embed
-        ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
-            embedSpec.setTitle("Help");
-            embedSpec.setAuthor(ctx.getSelf().getUsername(), null, ctx.getSelf().getAvatarUrl());
-            embedSpec.setFooter("See g!help <command> for help with specific commands", null);
-            embedSpec.setTimestamp(Instant.now());
-
-            for (Map.Entry<CommandType, List<ModuleInfo>> module : getCommandTypeToModuleInfoMap().entrySet()) {
-                List<String> names = module.getValue().stream().map(ModuleInfo::getName).collect(Collectors.toList());
-                String commandList = getFormattedListString("`", "`, `", "`", names)
-                        .orElse("No commands (...yet)");
-
-                CommandType type = module.getKey();
-                embedSpec.addField(type.getIcon() + " " + type.getFormattedName(), commandList, false);
-            }
-        })).block();
-    }
-
-
-    /**
-     * Categorizes all available modules.
-     *
-     * @return A map of all available sorts of `CommandType` and their corresponding `ModuleInfo`.
-     */
-    private Map<CommandType, List<ModuleInfo>> getCommandTypeToModuleInfoMap() {
-        Map<CommandType, List<ModuleInfo>> modules = new LinkedHashMap<>();
-
-        for (CommandType type : CommandType.values()) {
-            modules.put(type, new ArrayList<>());
-        }
-        for (ModuleInfo info : registry.getAllInfo()) {
-            modules.get(info.getType()).add(info);
-        }
-
-        return modules;
-    }
-
     /**
      * Sends a message detailing a single command, or an error message if the command is invalid.
      *
@@ -106,6 +61,33 @@ public final class ModuleHelp extends Module {
 
 
     /**
+     * Sends a message with a formatted embed enumerating all the commands in their respective `CommandType`.
+     *
+     * @param ctx The `CommandContext` to publish on.
+     */
+    private void fullCommandList(@NotNull CommandContext ctx) {
+
+        // Build and send embed
+        ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
+            embedSpec.setTitle("Help");
+            embedSpec.setAuthor(ctx.getSelf().getUsername(), null, ctx.getSelf().getAvatarUrl());
+            embedSpec.setFooter("See g!help <command> for help with specific commands", null);
+            embedSpec.setTimestamp(Instant.now());
+
+            for (Map.Entry<CommandType, List<ModuleInfo>> module : getCommandTypeToModuleInfoMap().entrySet()) {
+                List<String> names = module.getValue().stream().map(ModuleInfo::getName).collect(Collectors.toList());
+                String commandList = getFormattedListString("`", "`, `", "`", names)
+                        .orElse("No commands (...yet)");
+
+                CommandType type = module.getKey();
+                embedSpec.addField(type.getIcon() + " " + type.getFormattedName(), commandList, false);
+            }
+        })).block();
+    }
+
+
+
+    /**
      * Takes a list of `String`, and if they're empty, returns an empty `String`. If not, returns a `String` beginning
      * with the `before` `String`, intercalates the values with the `between` `String`, and appends the `after` `String`
      * at the end.
@@ -124,6 +106,24 @@ public final class ModuleHelp extends Module {
         }
 
         return Optional.of(before + joiner + after);
+    }
+
+    /**
+     * Categorizes all available modules.
+     *
+     * @return A map of all available sorts of `CommandType` and their corresponding `ModuleInfo`.
+     */
+    private Map<CommandType, List<ModuleInfo>> getCommandTypeToModuleInfoMap() {
+        Map<CommandType, List<ModuleInfo>> modules = new LinkedHashMap<>();
+
+        for (CommandType type : CommandType.values()) {
+            modules.put(type, new ArrayList<>());
+        }
+        for (ModuleInfo info : registry.getAllInfo()) {
+            modules.get(info.getType()).add(info);
+        }
+
+        return modules;
     }
 
     /**

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
@@ -2,21 +2,18 @@ package com.github.coleb1911.ghost2.commands.modules.info;
 
 import com.github.coleb1911.ghost2.Ghost2Application;
 import com.github.coleb1911.ghost2.commands.CommandRegistry;
-import com.github.coleb1911.ghost2.commands.meta.CommandContext;
-import com.github.coleb1911.ghost2.commands.meta.CommandType;
 import com.github.coleb1911.ghost2.commands.meta.Module;
-import com.github.coleb1911.ghost2.commands.meta.ModuleInfo;
-import com.github.coleb1911.ghost2.commands.meta.ReflectiveAccess;
+import com.github.coleb1911.ghost2.commands.meta.*;
 
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringJoiner;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public final class ModuleHelp extends Module {
+
+    private CommandRegistry registry;
+
     @ReflectiveAccess
     public ModuleHelp() {
         super(new ModuleInfo.Builder(ModuleHelp.class)
@@ -26,72 +23,124 @@ public final class ModuleHelp extends Module {
 
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
-        CommandRegistry registry = Ghost2Application.getApplicationInstance().getDispatcher().getRegistry();
+        //We cannot initialize the command registry earlier.
+        initializeRegistry();
 
-        // Single-command help
         if (ctx.getArgs().size() > 0) {
-            // Fetch & null-check CommandInfo
-            ModuleInfo info = registry.getInfo(ctx.getArgs().get(0));
-            if (null == info) {
-                ctx.reply(Module.REPLY_COMMAND_INVALID);
-                return;
-            }
-
-            // Build and send embed
-            ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
-                String aliasList;
-                if (info.getAliases().size() == 0) {
-                    aliasList = "n/a";
-                } else {
-                    StringJoiner joiner = new StringJoiner(", ");
-                    for (String alias : info.getAliases()) {
-                        joiner.add(alias);
-                    }
-                    aliasList = joiner.toString();
-                }
-
-                embedSpec.setTitle("Command help");
-                embedSpec.addField("Name", info.getName(), false);
-                embedSpec.addField("Description", info.getDescription(), false);
-                embedSpec.addField("Aliases", aliasList, false);
-                embedSpec.addField("Category", info.getType().getIcon() + info.getType().getFormattedName(), false);
-            })).block();
-        } else { // Full command list
-            // Categorize all available modules
-            Map<CommandType, List<ModuleInfo>> modules = new LinkedHashMap<>();
-
-            for (CommandType type : CommandType.values()) {
-                modules.put(type, new ArrayList<>());
-            }
-
-            for (ModuleInfo info : registry.getAllInfo()) {
-                modules.get(info.getType()).add(info);
-            }
-
-            // Build and send embed
-            ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
-                embedSpec.setTitle("Help");
-                embedSpec.setAuthor(ctx.getSelf().getUsername(), null, ctx.getSelf().getAvatarUrl());
-                embedSpec.setFooter("See g!help <command> for help with specific commands", null);
-                embedSpec.setTimestamp(Instant.now());
-
-                for (Map.Entry<CommandType, List<ModuleInfo>> module : modules.entrySet()) {
-                    String commandList;
-                    if (module.getValue().isEmpty()) {
-                        commandList = "No commands (...yet)";
-                    } else {
-                        StringJoiner joiner = new StringJoiner(", ");
-                        for (ModuleInfo info : module.getValue()) {
-                            joiner.add("`" + info.getName() + "`");
-                        }
-                        commandList = joiner.toString();
-                    }
-
-                    CommandType type = module.getKey();
-                    embedSpec.addField(type.getIcon() + " " + type.getFormattedName(), commandList, false);
-                }
-            })).block();
+            singleCommandHelp(ctx);
+        } else {
+            fullCommandList(ctx);
         }
     }
 
+
+    /**
+     * Sends a message with a formatted embed enumerating all the commands in their respective `CommandType`.
+     *
+     * @param ctx The `CommandContext` to publish on.
+     */
+    private void fullCommandList(@NotNull CommandContext ctx) {
+
+        // Build and send embed
+        ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
+            embedSpec.setTitle("Help");
+            embedSpec.setAuthor(ctx.getSelf().getUsername(), null, ctx.getSelf().getAvatarUrl());
+            embedSpec.setFooter("See g!help <command> for help with specific commands", null);
+            embedSpec.setTimestamp(Instant.now());
+
+            for (Map.Entry<CommandType, List<ModuleInfo>> module : getCommandTypeToModuleInfoMap().entrySet()) {
+                List<String> names = module.getValue().stream().map(ModuleInfo::getName).collect(Collectors.toList());
+                String commandList = getFormattedListString("No commands (...yet)", "`", "`, `", "`", names);
+
+                CommandType type = module.getKey();
+                embedSpec.addField(type.getIcon() + " " + type.getFormattedName(), commandList, false);
+            }
+        })).block();
+    }
+
+
+    /**
+     * Categorizes all available modules.
+     *
+     * @return A map of all available sorts of `CommandType` and their corresponding `ModuleInfo`.
+     */
+    private Map<CommandType, List<ModuleInfo>> getCommandTypeToModuleInfoMap() {
+        Map<CommandType, List<ModuleInfo>> modules = new LinkedHashMap<>();
+
+        for (CommandType type : CommandType.values()) {
+            modules.put(type, new ArrayList<>());
+        }
+        for (ModuleInfo info : registry.getAllInfo()) {
+            modules.get(info.getType()).add(info);
+        }
+
+        return modules;
+    }
+
+    /**
+     * Sends a message detailing a single command, or an error message if the command is invalid.
+     *
+     * @param ctx The `CommandContext` to publish on.
+     */
+    private void singleCommandHelp(@NotNull CommandContext ctx) {
+        // Fetch & null-check CommandInfo
+        ModuleInfo info = registry.getInfo(ctx.getArgs().get(0));
+        if (null == info) {
+            ctx.reply(Module.REPLY_COMMAND_INVALID);
+            return;
+        }
+
+        // Build and send embed
+        ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
+            String aliasesString = getFormattedListString("n/a", "", ", ", "", info.getAliases());
+
+            embedSpec.setTitle("Command help");
+            embedSpec.addField("Name", info.getName(), false);
+            embedSpec.addField("Description", info.getDescription(), false);
+            embedSpec.addField("Aliases", aliasesString, false);
+            embedSpec.addField("Category", info.getType().getIcon() + info.getType().getFormattedName(), false);
+        })).block();
+    }
+
+
+    /**
+     * Takes a list of `String`, and if they're empty, returns the `empty` `String`. If not, returns a `String` beginning
+     * with the `before` `String`, intercalates the values with the `between` `String`, and appends the `after` `String`
+     * at the end.
+     *
+     * @param empty   The `String` to be returned when the list of values is empty.
+     * @param before  A `String` to prepend to the result.
+     * @param between A `String` to intercalate between the list elements (ex.: ", ").
+     * @param after   A `String` to append to the result.
+     * @param values  The values to be displayed.
+     * @return A formatted string
+     */
+    private String getFormattedListString(String empty, String before,
+                                          String between, String after, List<String> values) {
+        StringBuilder result = new StringBuilder();
+
+        if (values.isEmpty()) {
+            result = new StringBuilder(empty);
+        } else {
+            result.append(before);
+
+            StringJoiner joiner = new StringJoiner(between);
+            for (String value : values) {
+                joiner.add(value);
+            }
+
+            result.append(joiner);
+            result.append(after);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Initializes the `CommandRegistry` the first time it is called.
+     */
+    private void initializeRegistry() {
+        if (registry == null) {
+            registry = Ghost2Application.getApplicationInstance().getDispatcher().getRegistry();
+        }
+    }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
@@ -50,7 +50,8 @@ public final class ModuleHelp extends Module {
 
             for (Map.Entry<CommandType, List<ModuleInfo>> module : getCommandTypeToModuleInfoMap().entrySet()) {
                 List<String> names = module.getValue().stream().map(ModuleInfo::getName).collect(Collectors.toList());
-                String commandList = getFormattedListString("No commands (...yet)", "`", "`, `", "`", names);
+                String commandList = getFormattedListString("`", "`, `", "`", names)
+                        .orElse("No commands (...yet)");
 
                 CommandType type = module.getKey();
                 embedSpec.addField(type.getIcon() + " " + type.getFormattedName(), commandList, false);
@@ -92,7 +93,8 @@ public final class ModuleHelp extends Module {
 
         // Build and send embed
         ctx.getChannel().createMessage(messageSpec -> messageSpec.setEmbed(embedSpec -> {
-            String aliasesString = getFormattedListString("n/a", "", ", ", "", info.getAliases());
+            String aliasesString = getFormattedListString("", ", ", "", info.getAliases())
+                    .orElse("n/a");
 
             embedSpec.setTitle("Command help");
             embedSpec.addField("Name", info.getName(), false);
@@ -104,35 +106,24 @@ public final class ModuleHelp extends Module {
 
 
     /**
-     * Takes a list of `String`, and if they're empty, returns the `empty` `String`. If not, returns a `String` beginning
+     * Takes a list of `String`, and if they're empty, returns an empty `String`. If not, returns a `String` beginning
      * with the `before` `String`, intercalates the values with the `between` `String`, and appends the `after` `String`
      * at the end.
      *
-     * @param empty   The `String` to be returned when the list of values is empty.
      * @param before  A `String` to prepend to the result.
      * @param between A `String` to intercalate between the list elements (ex.: ", ").
      * @param after   A `String` to append to the result.
      * @param values  The values to be displayed.
      * @return A formatted string
      */
-    private String getFormattedListString(String empty, String before,
-                                          String between, String after, List<String> values) {
-        StringBuilder result = new StringBuilder();
-
-        if (values.isEmpty()) {
-            result = new StringBuilder(empty);
-        } else {
-            result.append(before);
-
-            StringJoiner joiner = new StringJoiner(between);
-            for (String value : values) {
-                joiner.add(value);
-            }
-
-            result.append(joiner);
-            result.append(after);
+    private Optional<String> getFormattedListString(String before, String between, String after, List<String> values) {
+        if (values.isEmpty()) return Optional.empty();
+        StringJoiner joiner = new StringJoiner(between);
+        for (String value : values) {
+            joiner.add(value);
         }
-        return result.toString();
+
+        return Optional.of(before + joiner + after);
     }
 
     /**


### PR DESCRIPTION
# Changelist
- Refactoring in `ModuleHelp` to remove code duplication and long `invoke` (53 lines) method, effectively removing all code smells pointed out by CodeClimate in that class.
- Added documentation for all methods in class `ModuleHelp`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adds or revises project documentation)

## Local configuration:
- OS: Linux (Ubuntu 16.04)
- JDK: OpenJDK 11.0.4+11
