### PR TITLE
Fix string conversion bug in ModuleScreenshare

### DIFF
--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleScreenshare.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleScreenshare.java
@@ -3,8 +3,8 @@ package com.github.coleb1911.ghost2.commands.modules.utility;
 import com.github.coleb1911.ghost2.commands.meta.CommandContext;
 import com.github.coleb1911.ghost2.commands.meta.Module;
 import com.github.coleb1911.ghost2.commands.meta.ModuleInfo;
+import com.github.coleb1911.ghost2.commands.meta.ReflectiveAccess;
 import discord4j.core.object.VoiceState;
-import discord4j.core.object.util.Snowflake;
 
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
@@ -12,6 +12,7 @@ import java.util.Optional;
 public final class ModuleScreenshare extends Module {
     private static final String REPLY_NO_VOICE_CHANNEL = "You are not in a voice channel. Please join a voice channel to use the `screenshare` command.";
 
+    @ReflectiveAccess
     public ModuleScreenshare() {
         super(new ModuleInfo.Builder(ModuleScreenshare.class)
                 .withName("screenshare")
@@ -21,12 +22,19 @@ public final class ModuleScreenshare extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         // Check if user is connected to a voice channel
-        Optional<Snowflake> channelIdOptional = ctx.getInvoker().getVoiceState().map(VoiceState::getChannelId).block();
-        if (Optional.empty().equals(channelIdOptional)) {
-            ctx.reply(REPLY_NO_VOICE_CHANNEL);
-            return;
-        }
+        ctx.getInvoker().getVoiceState()
+                .map(VoiceState::getChannelId)
+                .defaultIfEmpty(Optional.empty())
+                .subscribe(opt -> {
+                    if (opt.isEmpty()) {
+                        ctx.reply(REPLY_NO_VOICE_CHANNEL);
+                        return;
+                    }
 
-        ctx.reply("https://discordapp.com/channels/" + ctx.getGuild().getId().asLong() + "/" + channelIdOptional);
+                    ctx.reply("https://discordapp.com/channels/" +
+                            ctx.getGuild().getId().asString() +
+                            "/" +
+                            opt.get().asString());
+                });
     }
 }


### PR DESCRIPTION
# Changelist
- Fix incorrect conversion of voice channel ID
- Remove blocking call
- Better null-safety
- Add `@ReflectiveAccess` to constructor

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adds or revises project documentation)

## Local configuration:
- OS: Windows 10 x64
- JDK: AdoptOpenJDK 11.0.4+11