### PR TITLE
doc: fixed bad links to point at project account and wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 # ghost2 [![Build Status](https://travis-ci.org/ghost2-discord/ghost2.svg?branch=master)](https://travis-ci.org/ghost2-discord/ghost2) [![Maintainability](https://api.codeclimate.com/v1/badges/9cbad0d3562a8670ec20/maintainability)](https://codeclimate.com/github/cbryant02/ghost2/maintainability) [![Code Helpers](https://www.codetriage.com/cbryant02/ghost2/badges/users.svg)](https://www.codetriage.com/cbryant02/ghost2) [![Gitter](https://badges.gitter.im/ghost2-dev/community.svg)](https://gitter.im/ghost2-dev/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-ghost2 is a modular, multi-feature Discord bot, and the spiritual successor to the original [ghost](https://github.com/cbryant02/ghost).
+ghost2 is a modular, multi-feature Discord bot, and the spiritual successor to the original [ghost](https://github.com/ghost2-discord/ghost).
 Among its features are a Spring-powered persistence layer, an embedded H2 database, simpler command modules,
 Discord4J 3, and approximately 99.8% less spaghetti.
 
 ## Documentation
-All the available documentation can be found in the [project wiki](https://github.com/cbryant02/ghost2/wiki). Here are some starter topics for end-users:
+All the available documentation can be found in the [project wiki](https://github.com/ghost2-discord/ghost2/wiki). Here are some starter topics for end-users:
 
-  - For help using the bot, refer to [*Using ghost2*](https://github.com/cbryant02/ghost2/wiki/Using-ghost2).
-  - To run the bot, [download a release](https://github.com/cbryant02/ghost2/releases) and refer to [*Configuring and running*](https://github.com/cbryant02/ghost2/wiki/Configuring-and-running).
+  - For help using the bot, refer to [*Using ghost2*](https://github.com/ghost2-discord/ghost2/wiki/Using-ghost2).
+  - To run the bot, [download a release](https://github.com/ghost2-discord/ghost2/releases) and refer to [*Configuring and running*](https://github.com/ghost2-discord/ghost2/wiki/Configuring-and-running).
 
 ## Contributing
-Pull requests are totally welcome; ghost2 is maintained entirely by open-source contributors. If you want to help, see [CONTRIBUTING.md](https://github.com/cbryant02/ghost2/blob/master/CONTRIBUTING.md)
-and read the full [contributor's guide](https://github.com/cbryant02/ghost2/wiki/Contributor's-guide) for more information on getting your code into the project.
+Pull requests are totally welcome; ghost2 is maintained entirely by open-source contributors. If you want to help, see [CONTRIBUTING.md](https://github.com/ghost2-discord/ghost2/blob/master/CONTRIBUTING.md)
+and read the full [contributor's guide](https://github.com/ghost2-discord/ghost2/wiki/Contributor's-guide) for more information on getting your code into the project.


### PR DESCRIPTION
# Changelist
- Update doc links to point at the ghost2-dicord repository instead of cbryant

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adds or revises project documentation)

## Local configuration:
- OS: OSX
- JDK: OpenJDK Runtime Environment Zulu11.33+15-CA (build 11.0.4+11-LTS)

I noticed that none of the wiki links worked, because it looks like you've moved your wiki from your personal github account fork to the project account fork, but the README links were still pointing at your personal account.