### PR TITLE
Support for Heroku deployment (+ some refactoring)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: java -Dserver.port=$PORT $JAVA_OPTS -jar build/libs/*.jar

--- a/src/main/java/com/github/coleb1911/ghost2/Ghost2Application.java
+++ b/src/main/java/com/github/coleb1911/ghost2/Ghost2Application.java
@@ -46,7 +46,8 @@ import java.util.function.Predicate;
 public class Ghost2Application implements ApplicationRunner {
     private static final String MESSAGE_SET_OPERATOR = "No operator has been set for this bot instance. Use the \'claimoperator\' command to set one; until then, operator commands won't work.";
     private static final String ERROR_CONNECTION = "General connection error. Check your internet connection and try again.";
-    private static final String ERROR_CONFIG = "ghost.properties is missing or does not contain a bot token. Read ghost2's README for info on how to set up the bot.";
+    private static final String ERROR_CONFIG = "ghost.properties is missing or does not contain a bot token, and no fallback environment variable could be read.\n" +
+            "Read ghost2's README for info on how to set up the bot.";
 
     private final ApplicationContext ctx;
     private final CommandDispatcher dispatcher;

--- a/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
+++ b/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
@@ -2,11 +2,14 @@ package com.github.coleb1911.ghost2;
 
 import org.aeonbits.owner.Accessible;
 import org.aeonbits.owner.Config;
+import org.aeonbits.owner.Config.LoadPolicy;
+import org.aeonbits.owner.Config.LoadType;
 import org.aeonbits.owner.Config.Sources;
 import org.aeonbits.owner.Mutable;
 import org.aeonbits.owner.Reloadable;
 
-@Sources("classpath:ghost.properties")
+@LoadPolicy(LoadType.MERGE)
+@Sources({"classpath:ghost.properties", "system:env"})
 public interface GhostConfig extends Config, Accessible, Mutable, Reloadable {
     @Key("ghost.token")
     String token();
@@ -18,5 +21,4 @@ public interface GhostConfig extends Config, Accessible, Mutable, Reloadable {
     @Key("ghost.w2g_api_key")
     @DefaultValue("ujww234232ewegwgwef4d")
     String w2g_api_key();
-
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
@@ -98,13 +98,13 @@ public final class CommandDispatcher {
         // Check user's permissions
         PermissionSet invokerPerms = ctx.getInvoker().getBasePermissions().block();
         if (null == invokerPerms) {
-            ctx.reply(Module.REPLY_GENERAL_ERROR);
+            ctx.replyBlocking(Module.REPLY_GENERAL_ERROR);
             return false;
         }
         if (!invokerPerms.contains(Permission.ADMINISTRATOR)) {
             for (Permission required : module.getInfo().getUserPermissions()) {
                 if (!invokerPerms.contains(required)) {
-                    ctx.reply(Module.REPLY_INSUFFICIENT_PERMISSIONS_USER);
+                    ctx.replyBlocking(Module.REPLY_INSUFFICIENT_PERMISSIONS_USER);
                     return false;
                 }
             }
@@ -116,20 +116,20 @@ public final class CommandDispatcher {
                 (module.getInfo().getType() == CommandType.OPERATOR) &&
                 (ctx.getInvoker().getId().asLong() != References.getConfig().operatorId())) {
 
-            ctx.reply(Module.REPLY_INSUFFICIENT_PERMISSIONS_USER);
+            ctx.replyBlocking(Module.REPLY_INSUFFICIENT_PERMISSIONS_USER);
             return false;
         }
 
         // Check bot's permissions
         PermissionSet botPerms = ctx.getSelf().getBasePermissions().block();
         if (null == botPerms) {
-            ctx.reply(Module.REPLY_GENERAL_ERROR);
+            ctx.replyBlocking(Module.REPLY_GENERAL_ERROR);
             return false;
         }
         if (!botPerms.contains(Permission.ADMINISTRATOR)) {
             for (Permission required : module.getInfo().getBotPermissions()) {
                 if (!botPerms.contains(required)) {
-                    ctx.reply(Module.REPLY_INSUFFICIENT_PERMISSIONS_BOT);
+                    ctx.replyBlocking(Module.REPLY_INSUFFICIENT_PERMISSIONS_BOT);
                     return false;
                 }
             }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
@@ -88,10 +88,14 @@ public final class CommandDispatcher {
         }
 
         // Finally kick off command thread if all checks are passed
-
-        executor.execute(() -> ctx.getChannel()
-                .typeUntil(Mono.fromRunnable(() -> module.invoke(ctx)))
-                .subscribe());
+        executor.execute(() -> {
+            Mono<?> invokeMono = Mono.fromRunnable(() -> module.invoke(ctx));
+            if (module.getInfo().shouldType()) {
+                ctx.getChannel()
+                        .typeUntil(invokeMono)
+                        .subscribe();
+            } else invokeMono.subscribe();
+        });
     }
 
     private boolean checkPerms(final Module module, final CommandContext ctx) {

--- a/src/main/java/com/github/coleb1911/ghost2/commands/meta/CommandContext.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/meta/CommandContext.java
@@ -85,18 +85,67 @@ public class CommandContext {
         return roleMentions;
     }
 
-    public void reply(String message) {
-        channel.createMessage(message).subscribe();
+    /**
+     * Reply to a command.
+     *
+     * @param text Reply message content
+     * @return {@linkplain Mono} containing the reply {@linkplain Message}
+     */
+    public Mono<Message> reply(String text) {
+        return channel.createMessage(text);
     }
 
-    public void replyDirect(String message) {
-        invoker.getPrivateChannel()
-                .flatMap(ch -> ch.createMessage(message))
-                .subscribe();
+    /**
+     * Reply to a command via direct message.
+     *
+     * @param text Reply message content
+     * @return {@linkplain Mono} containing the reply {@linkplain Message}
+     */
+    public Mono<Message> replyDirect(String text) {
+        return invoker.getPrivateChannel()
+                .flatMap(ch -> ch.createMessage(text));
     }
 
+    /**
+     * Reply to a command with an embed.
+     *
+     * @param consumer Embed spec consumer
+     * @return {@linkplain Mono} containing the reply {@linkplain Message}
+     * @see <a href="https://github.com/Discord4J/Discord4J/wiki/Specs">Specs</a>
+     */
     public Mono<Message> replyEmbed(Consumer<EmbedCreateSpec> consumer) {
         return channel.createEmbed(consumer);
+    }
+
+    /**
+     * Reply to a command. Blocks until finished.
+     *
+     * @param text Reply message content
+     * @return The reply {@linkplain Message}
+     */
+    public Message replyBlocking(String text) {
+        return reply(text).block();
+    }
+
+    /**
+     * Reply to a command via direct message. Blocks until finished.
+     *
+     * @param text Reply message content
+     * @return The reply {@linkplain Message}
+     */
+    public Message replyDirectBlocking(String text) {
+        return replyDirect(text).block();
+    }
+
+    /**
+     * Reply to a command with an embed. Blocks until finished.
+     *
+     * @param consumer Embed spec consumer
+     * @return The reply {@linkplain Message}
+     * @see <a href="https://github.com/Discord4J/Discord4J/wiki/Specs">Specs</a>
+     */
+    public Message replyEmbedBlocking(Consumer<EmbedCreateSpec> consumer) {
+        return replyEmbed(consumer).block();
     }
 
     private List<String> extractArgs(Message message) {

--- a/src/main/java/com/github/coleb1911/ghost2/commands/meta/InvalidModuleException.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/meta/InvalidModuleException.java
@@ -90,7 +90,7 @@ public class InvalidModuleException extends RuntimeException {
         INVALID_BOT_PERMISSIONS("Module has a null bot permission list"),
         INVALID_USER_PERMISSIONS("Module has a null user permission list"),
         INVALID_TYPE("Module has a null type"),
-        INVALID_ALIASES("Module has a null alias array");
+        INVALID_ALIASES("Module has a null alias list");
 
         private final String message;
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/meta/ModuleInfo.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/meta/ModuleInfo.java
@@ -31,14 +31,22 @@ public final class ModuleInfo {
     private final PermissionSet userPermissions;
     private final CommandType type;
     private final List<String> aliases;
+    private final boolean showTypingIndicator;
 
-    private ModuleInfo(String name, String description, PermissionSet botPermissions, PermissionSet userPermissions, CommandType type, String[] aliases) {
+    private ModuleInfo(String name,
+                       String description,
+                       PermissionSet botPermissions,
+                       PermissionSet userPermissions,
+                       CommandType type,
+                       String[] aliases,
+                       boolean showTypingIndicator) {
         this.name = name.toLowerCase();
         this.description = description;
         this.botPermissions = botPermissions;
         this.userPermissions = userPermissions;
         this.type = type;
         this.aliases = Arrays.stream(aliases).map(String::toLowerCase).collect(Collectors.toUnmodifiableList());
+        this.showTypingIndicator = showTypingIndicator;
     }
 
     /**
@@ -84,6 +92,13 @@ public final class ModuleInfo {
     }
 
     /**
+     * @return Whether or not this command should show a typing indicator during execution
+     */
+    public boolean shouldType() {
+        return showTypingIndicator;
+    }
+
+    /**
      * The builder class for ModuleInfo.
      * <p>
      * Every {@link Module} subclass must construct themselves with a valid ModuleInfo in order to be considered a valid command.
@@ -111,6 +126,7 @@ public final class ModuleInfo {
         @NotNull private PermissionSet botPermissions;
         @NotNull private PermissionSet userPermissions;
         @NotNull private String[] aliases;
+        @NotNull private boolean showTypingIndicator = false;
 
         /**
          * Constructs a new CommandInfo builder.<br>
@@ -201,13 +217,28 @@ public final class ModuleInfo {
         }
 
         /**
+         * Make this Module show a typing indicator while it is executing. Good for
+         * providing feedback during long-running commands.
+         * <p>
+         * Note that because of the way the Discord API handles typing indicators,
+         * your command should send a message when it is done in order to hide the
+         * indicator. If not, it'll persist for at least 10 seconds before it disappears.
+         *
+         * @return this Builder
+         */
+        public Builder showTypingIndicator() {
+            this.showTypingIndicator = true;
+            return this;
+        }
+
+        /**
          * Builds the {@code CommandInfo}.
          *
          * @return A {@code CommandInfo} object built from the parameters provided to this Builder
          */
         ModuleInfo build() {
             checkValid();
-            return new ModuleInfo(name, description, botPermissions, userPermissions, type, aliases);
+            return new ModuleInfo(name, description, botPermissions, userPermissions, type, aliases, showTypingIndicator);
         }
 
         /**

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/config/ModuleAutoRole.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/config/ModuleAutoRole.java
@@ -42,11 +42,11 @@ public final class ModuleAutoRole extends Module {
      */
     private static void enableConfirmation(final CommandContext ctx, final GuildMeta meta) {
         if (meta.getAutoRoleConfirmationEnabled()) {
-            ctx.reply("Autorole confirmation is already enabled.");
+            ctx.replyBlocking("Autorole confirmation is already enabled.");
             return;
         }
         meta.setAutoRoleConfirmationEnabled(true);
-        ctx.reply("Autorole confirmation enabled.");
+        ctx.replyBlocking("Autorole confirmation enabled.");
     }
 
     /**
@@ -57,11 +57,11 @@ public final class ModuleAutoRole extends Module {
      */
     private static void disableConfirmation(final CommandContext ctx, final GuildMeta meta) {
         if (!meta.getAutoRoleConfirmationEnabled()) {
-            ctx.reply("Autorole confirmation is already disabled.");
+            ctx.replyBlocking("Autorole confirmation is already disabled.");
             return;
         }
         meta.setAutoRoleConfirmationEnabled(false);
-        ctx.reply("Autorole confirmation disabled.");
+        ctx.replyBlocking("Autorole confirmation disabled.");
     }
 
     /**
@@ -75,19 +75,19 @@ public final class ModuleAutoRole extends Module {
         Role highest = ctx.getSelf().getHighestRole().block();
 
         if (highest == null || role.getRawPosition() > highest.getRawPosition()) {
-            ctx.reply("That role is higher than my highest role. I can't use it.");
+            ctx.replyBlocking("That role is higher than my highest role. I can't use it.");
             return;
         }
 
         meta.setAutoRoleId(role.getId().asLong());
-        ctx.reply("Autorole set to " + role.getMention() + ".");
+        ctx.replyBlocking("Autorole set to " + role.getMention() + ".");
     }
 
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
         // Check for arguments
         if (ctx.getArgs().isEmpty() || ctx.getMessage().mentionsEveryone()) {
-            ctx.reply(REPLY_INVALID_ARGS);
+            ctx.replyBlocking(REPLY_INVALID_ARGS);
             return;
         }
 
@@ -102,7 +102,7 @@ public final class ModuleAutoRole extends Module {
                 break;
             case ARG_SET_CONFIRM_ENABLED:
                 if (ctx.getArgs().size() < 2) {
-                    ctx.reply(REPLY_INVALID_CONFIRM_SETTING);
+                    ctx.replyBlocking(REPLY_INVALID_CONFIRM_SETTING);
                     return;
                 }
                 switch (ctx.getArgs().get(1)) {
@@ -113,7 +113,7 @@ public final class ModuleAutoRole extends Module {
                         disableConfirmation(ctx, meta);
                         break;
                     default:
-                        ctx.reply(REPLY_INVALID_CONFIRM_SETTING);
+                        ctx.replyBlocking(REPLY_INVALID_CONFIRM_SETTING);
                         break;
                 }
                 break;
@@ -134,16 +134,16 @@ public final class ModuleAutoRole extends Module {
      */
     private void enableAutoRole(final CommandContext ctx, final GuildMeta meta) {
         if (meta.getAutoRoleId() == null) {
-            ctx.reply("Please set a role for autorole before enabling it.");
+            ctx.replyBlocking("Please set a role for autorole before enabling it.");
             return;
         }
 
         if (meta.getAutoRoleEnabled()) {
-            ctx.reply("Autorole is already enabled.");
+            ctx.replyBlocking("Autorole is already enabled.");
             return;
         }
         meta.setAutoRoleEnabled(true);
-        ctx.reply("Autorole enabled.");
+        ctx.replyBlocking("Autorole enabled.");
     }
 
     /**
@@ -154,10 +154,10 @@ public final class ModuleAutoRole extends Module {
      */
     private void disableAutoRole(final CommandContext ctx, final GuildMeta meta) {
         if (!meta.getAutoRoleEnabled()) {
-            ctx.reply("Autorole is already disabled.");
+            ctx.replyBlocking("Autorole is already disabled.");
             return;
         }
         meta.setAutoRoleEnabled(false);
-        ctx.reply("Autorole disabled.");
+        ctx.replyBlocking("Autorole disabled.");
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/config/ModulePrefix.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/config/ModulePrefix.java
@@ -25,14 +25,14 @@ public final class ModulePrefix extends Module {
     public void invoke(@NotNull final CommandContext ctx) {
         // Check for at least one argument
         if (ctx.getArgs().isEmpty()) {
-            ctx.reply("You didn't supply a prefix.");
+            ctx.replyBlocking("You didn't supply a prefix.");
             return;
         }
 
         // Get prefix and check length
         String prefix = ctx.getArgs().get(0);
         if (prefix.length() > GuildMeta.PREFIX_LENGTH) {
-            ctx.reply("That prefix is too long. The maximum prefix length is " + GuildMeta.PREFIX_LENGTH + ".");
+            ctx.replyBlocking("That prefix is too long. The maximum prefix length is " + GuildMeta.PREFIX_LENGTH + ".");
             return;
         }
 
@@ -40,6 +40,6 @@ public final class ModulePrefix extends Module {
         GuildMeta meta = guildRepo.findById(ctx.getGuild().getId().asLong()).orElseThrow();
         meta.setPrefix(prefix);
         guildRepo.save(meta);
-        ctx.reply("Set prefix to `" + prefix + "`.");
+        ctx.replyBlocking("Set prefix to `" + prefix + "`.");
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWatch2gether.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWatch2gether.java
@@ -44,13 +44,13 @@ public final class ModuleWatch2gether extends Module {
         try {
             final Watch2getherResponse room = restTemplate.postForObject(W2G_URL, new HttpEntity<>(new ModuleWatch2gether.Watch2getherRequest()), ModuleWatch2gether.Watch2getherResponse.class);
             if (room == null) {
-                ctx.reply("Error trying to create a Watch2Gether room.");
+                ctx.replyBlocking("Error trying to create a Watch2Gether room.");
                 return;
             }
 
-            ctx.reply(room.getUrl());
+            ctx.replyBlocking(room.getUrl());
         } catch (HttpStatusCodeException exception) {
-            ctx.reply("Error trying to retrieve the Watch2Gether room.");
+            ctx.replyBlocking("Error trying to retrieve the Watch2Gether room.");
         }
     }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWikipedia.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWikipedia.java
@@ -73,14 +73,14 @@ public final class ModuleWikipedia extends Module {
                 })).block();
             } else {
                 if (searchInfo.hasSuggestions()) {
-                    ctx.reply("Did you mean \"" + searchInfo.getSuggestion() + "\"?");
+                    ctx.replyBlocking("Did you mean \"" + searchInfo.getSuggestion() + "\"?");
                 } else {
-                    ctx.reply("Couldn't find anything about \"" + searchString + "\" on wikipedia.");
+                    ctx.replyBlocking("Couldn't find anything about \"" + searchString + "\" on wikipedia.");
                 }
             }
         } catch (RestClientException ex) {
             response = "Error: " + ex.toString();
-            ctx.reply(response);
+            ctx.replyBlocking(response);
         }
     }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleXKCD.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleXKCD.java
@@ -42,7 +42,7 @@ public final class ModuleXKCD extends Module {
         if (ctx.getArgs().isEmpty()) {
             final XKCDComic latest = TEMPLATE.getForObject(BASE_URL + "info.0.json", XKCDComic.class);
             if (latest == null) {
-                ctx.reply(REPLY_FETCH_ERROR);
+                ctx.replyBlocking(REPLY_FETCH_ERROR);
                 return;
             }
 
@@ -54,7 +54,7 @@ public final class ModuleXKCD extends Module {
         try {
             final XKCDComic comic = TEMPLATE.getForObject(url + "/info.0.json", XKCDComic.class);
             if (comic == null) {
-                ctx.reply(REPLY_FETCH_ERROR);
+                ctx.replyBlocking(REPLY_FETCH_ERROR);
                 return;
             }
 
@@ -66,7 +66,7 @@ public final class ModuleXKCD extends Module {
                     .setUrl(BASE_URL + comic.getNum())
             ).subscribe();
         } catch (HttpStatusCodeException exception) {
-            ctx.reply(REPLY_FETCH_ERROR);
+            ctx.replyBlocking(REPLY_FETCH_ERROR);
         }
     }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
@@ -29,7 +29,8 @@ public final class ModuleHelp extends Module {
     public ModuleHelp() {
         super(new ModuleInfo.Builder(ModuleHelp.class)
                 .withName("help")
-                .withDescription("List commands or get help with a specific command"));
+                .withDescription("List commands or get help with a specific command")
+                .showTypingIndicator());
     }
 
     @Override

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleHelp.java
@@ -50,7 +50,7 @@ public final class ModuleHelp extends Module {
         // Fetch & null-check CommandInfo
         ModuleInfo info = registry.getInfo(ctx.getArgs().get(0));
         if (null == info) {
-            ctx.reply(Module.REPLY_COMMAND_INVALID);
+            ctx.replyBlocking(Module.REPLY_COMMAND_INVALID);
             return;
         }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleInvite.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleInvite.java
@@ -20,6 +20,6 @@ public final class ModuleInvite extends Module {
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
         Snowflake clientId = Objects.requireNonNull(ctx.getClient().getApplicationInfo().block()).getId();
-        ctx.reply("https://discordapp.com/oauth2/authorize?client_id=" + clientId.asLong() + "&scope=bot&permissions=3214336");
+        ctx.replyBlocking("https://discordapp.com/oauth2/authorize?client_id=" + clientId.asLong() + "&scope=bot&permissions=3214336");
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleInvite.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/info/ModuleInvite.java
@@ -14,7 +14,8 @@ public final class ModuleInvite extends Module {
     public ModuleInvite() {
         super(new ModuleInfo.Builder(ModuleInvite.class)
                 .withName("invite")
-                .withDescription("Generates invite link for the bot"));
+                .withDescription("Generates invite link for the bot")
+                .showTypingIndicator());
     }
 
     @Override

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleBan.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleBan.java
@@ -20,7 +20,7 @@ public final class ModuleBan extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         if(ctx.getArgs().isEmpty()) {
-            ctx.reply("Please specify a user.");
+            ctx.replyBlocking("Please specify a user.");
             return;
         }
 
@@ -29,11 +29,11 @@ public final class ModuleBan extends Module {
                 .filter(member -> targetName.equals(member.getDisplayName()))
                 .map(member -> member.ban(spec -> {
                     spec.setReason("Banned by " + ctx.getInvoker().getDisplayName());
-                    ctx.reply(member.getDisplayName() + " was banned.");
+                    ctx.replyBlocking(member.getDisplayName() + " was banned.");
                 }).subscribe())
                 .hasElements()
                 .flatMap(aBoolean -> {
-                    if (!aBoolean) ctx.reply("User not found.");
+                    if (!aBoolean) ctx.replyBlocking("User not found.");
                     return Mono.just(aBoolean);
                 })
                 .subscribe();

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleConfirm.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleConfirm.java
@@ -37,18 +37,18 @@ public final class ModuleConfirm extends Module {
             Role role = ctx.getGuild().getRoleById(Snowflake.of(meta.getAutoRoleId())).block();
             Role highest = ctx.getSelf().getHighestRole().block();
             if (null == role || null == highest || role.getRawPosition() > highest.getRawPosition()) {
-                ctx.reply("Autorole is configured to use an invalid role. Notify an admin.");
+                ctx.replyBlocking("Autorole is configured to use an invalid role. Notify an admin.");
                 return;
             }
 
             if (!ctx.getInvoker().getRoleIds().contains(role.getId())) {
                 ctx.getInvoker().addRole(role.getId(), "Autorole").subscribe();
-                ctx.replyDirect("You have received your role.");
+                ctx.replyDirectBlocking("You have received your role.");
             } else {
-                ctx.replyDirect("You already have " + ctx.getGuild().getName() + "'s base role.");
+                ctx.replyDirectBlocking("You already have " + ctx.getGuild().getName() + "'s base role.");
             }
         } else {
-            ctx.replyDirect("Autorole confirmation is disabled. Your roles have not changed.");
+            ctx.replyDirectBlocking("Autorole confirmation is disabled. Your roles have not changed.");
         }
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleKick.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleKick.java
@@ -24,7 +24,7 @@ public final class ModuleKick extends Module {
     public void invoke(@NotNull final CommandContext ctx) {
         // Check for args
         if (ctx.getArgs().isEmpty()) {
-            ctx.reply("Please specify a user.");
+            ctx.replyBlocking("Please specify a user.");
             return;
         }
 
@@ -34,7 +34,7 @@ public final class ModuleKick extends Module {
             target.asMember(ctx.getGuild().getId())
                     .doOnError(e -> {
                         if (e instanceof ClientException && ((ClientException) e).getStatus().code() == 50013)
-                            ctx.reply("I don't have permission to kick that user.");
+                            ctx.replyBlocking("I don't have permission to kick that user.");
                     })
                     .subscribe(m -> m.kick().subscribe());
         } else {
@@ -42,7 +42,7 @@ public final class ModuleKick extends Module {
             ctx.getGuild().getMembers()
                     .doOnError(e -> {
                         if (e instanceof ClientException && ((ClientException) e).getStatus().code() == 50013)
-                            ctx.reply("I don't have permission to kick that user.");
+                            ctx.replyBlocking("I don't have permission to kick that user.");
                     })
                     .take(1)
                     .filter(member -> targetName.equals(member.getDisplayName()))
@@ -50,7 +50,7 @@ public final class ModuleKick extends Module {
                     .collectList()
                     .subscribe(monos -> {
                         if (monos.isEmpty())
-                            ctx.reply("No user found with that name.");
+                            ctx.replyBlocking("No user found with that name.");
                     });
         }
     }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleMute.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModuleMute.java
@@ -20,7 +20,7 @@ public final class ModuleMute extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         if(ctx.getArgs().isEmpty()) {
-            ctx.reply("Please specify a user.");
+            ctx.replyBlocking("Please specify a user.");
             return;
         }
 
@@ -29,11 +29,11 @@ public final class ModuleMute extends Module {
                 .filter(member -> targetName.equals(member.getDisplayName()))
                 .map(member -> member.edit(spec -> {
                     spec.setMute(true);
-                    ctx.reply(member.getDisplayName() + " is now muted.");
+                    ctx.replyBlocking(member.getDisplayName() + " is now muted.");
                 }).subscribe())
                 .hasElements()
                 .flatMap(aBoolean -> {
-                    if (!aBoolean) ctx.reply("User not found.");
+                    if (!aBoolean) ctx.replyBlocking("User not found.");
                     return Mono.just(aBoolean);
                 })
                 .subscribe();

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModulePurge.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/moderation/ModulePurge.java
@@ -23,7 +23,7 @@ public final class ModulePurge extends Module {
     public void invoke(@NotNull final CommandContext ctx) {
         // Check for arguments
         if (ctx.getArgs().isEmpty()) {
-            ctx.reply("Please specify a number of messages to purge.");
+            ctx.replyBlocking("Please specify a number of messages to purge.");
             return;
         }
 
@@ -32,7 +32,7 @@ public final class ModulePurge extends Module {
         try {
             count = Integer.parseInt(ctx.getArgs().get(0));
         } catch (NumberFormatException e) {
-            ctx.reply(Module.REPLY_ARGUMENT_INVALID);
+            ctx.replyBlocking(Module.REPLY_ARGUMENT_INVALID);
             return;
         }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleLeave.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleLeave.java
@@ -21,7 +21,7 @@ public final class ModuleLeave extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         if (!MusicServiceManager.serviceExists(ctx.getGuild().getId())) {
-            ctx.reply("I'm not playing music right now.");
+            ctx.replyBlocking("I'm not playing music right now.");
             return;
         }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModulePlay.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModulePlay.java
@@ -20,7 +20,8 @@ public final class ModulePlay extends Module {
         super(new ModuleInfo.Builder(ModulePlay.class)
                 .withName("play")
                 .withDescription("Play or queue a track.")
-                .withAliases("queueadd", "qa"));
+                .withAliases("queueadd", "qa")
+                .showTypingIndicator());
     }
 
     @Override

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModulePlay.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModulePlay.java
@@ -26,7 +26,7 @@ public final class ModulePlay extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         if (ctx.getArgs().isEmpty()) {
-            ctx.reply("Please provide a link to a valid track.");
+            ctx.replyBlocking("Please provide a link to a valid track.");
             return;
         }
 
@@ -45,8 +45,8 @@ public final class ModulePlay extends Module {
         MusicUtils.fetchMusicService(ctx)
                 .flatMap(service -> service.loadTrack(source.get()))
                 .subscribe(result -> {
-                    if (title.get() != null) ctx.reply("Queued **" + title + "**.");
-                    else ctx.reply(result.message);
+                    if (title.get() != null) ctx.replyBlocking("Queued **" + title + "**.");
+                    else ctx.replyBlocking(result.message);
                 });
     }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleQueue.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleQueue.java
@@ -41,7 +41,7 @@ public final class ModuleQueue extends Module {
                 .collectList()
                 .subscribe(tracks -> {
                     if (tracks.isEmpty()) {
-                        ctx.reply("Queue is empty.");
+                        ctx.replyBlocking("Queue is empty.");
                         return;
                     }
 
@@ -60,7 +60,7 @@ public final class ModuleQueue extends Module {
             this.ctx = ctx;
 
             if (tracks.isEmpty()) {
-                ctx.reply("Queue is empty.");
+                ctx.replyBlocking("Queue is empty.");
                 return;
             }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleQueue.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleQueue.java
@@ -30,7 +30,8 @@ public final class ModuleQueue extends Module {
     public ModuleQueue() {
         super(new ModuleInfo.Builder(ModuleQueue.class)
                 .withName("queue")
-                .withDescription("Show the current tracks in the queue."));
+                .withDescription("Show the current tracks in the queue.")
+                .showTypingIndicator());
     }
 
     @Override

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleRemove.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleRemove.java
@@ -27,7 +27,7 @@ public final class ModuleRemove extends Module {
         try {
             index = Integer.parseInt(ctx.getArgs().get(0));
         } catch (NumberFormatException e) {
-            ctx.reply("That's not a number.");
+            ctx.replyBlocking("That's not a number.");
             return;
         }
 
@@ -35,10 +35,10 @@ public final class ModuleRemove extends Module {
                 .flatMap(svc -> svc.remove(index-1))
                 .subscribe(success -> {
                     if (success) {
-                        ctx.reply("Removed track " + index + ".");
+                        ctx.replyBlocking("Removed track " + index + ".");
                         return;
                     }
-                    ctx.reply("Invalid track number.");
+                    ctx.replyBlocking("Invalid track number.");
                 });
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleRemove.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/music/ModuleRemove.java
@@ -13,7 +13,8 @@ public final class ModuleRemove extends Module {
     public ModuleRemove() {
         super(new ModuleInfo.Builder(ModuleRemove.class)
                 .withName("remove")
-                .withDescription("Remove the track at the given index."));
+                .withDescription("Remove the track at the given index.")
+                .showTypingIndicator());
     }
 
     @Override

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleClaimOperator.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleClaimOperator.java
@@ -50,7 +50,7 @@ public final class ModuleClaimOperator extends Module {
         String key = generateRandomString();
 
         // Log key and prompt user for it
-        ctx.reply(REPLY_PROMPT);
+        ctx.replyBlocking(REPLY_PROMPT);
         Logger.info("Your key: " + key);
 
         // Listen for & validate key
@@ -62,7 +62,7 @@ public final class ModuleClaimOperator extends Module {
                 .take(1)
                 .doOnNext(event -> {
                     if (event.getMessage().getContent().orElse("").equals(key)) {
-                        ctx.reply(REPLY_VALID);
+                        ctx.replyBlocking(REPLY_VALID);
                         GhostConfig cfg = References.getConfig();
                         cfg.setProperty("ghost.operatorid", event.getMember().orElseThrow().getId().asString());
                         URI cfgUri;
@@ -77,7 +77,7 @@ public final class ModuleClaimOperator extends Module {
                         }
                     }
                 })
-                .timeout(Duration.of(30L, ChronoUnit.SECONDS), s -> ctx.reply(REPLY_TIMEOUT))
+                .timeout(Duration.of(30L, ChronoUnit.SECONDS), s -> ctx.replyBlocking(REPLY_TIMEOUT))
                 .blockFirst();
 
         // Reload configuration

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleShutdown.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/operator/ModuleShutdown.java
@@ -18,7 +18,7 @@ public final class ModuleShutdown extends Module {
 
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
-        ctx.reply("Bye!");
+        ctx.replyBlocking("Bye!");
         References.getInstance().exit(0);
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleDefine.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleDefine.java
@@ -57,12 +57,12 @@ public final class ModuleDefine extends Module {
         try {
             specConsumer = createDefinitionEmbed(word);
         } catch (HttpServerErrorException e) {
-            ctx.reply(REPLY_SERVER_ERROR + "(" + e.getStatusCode().toString() + ")");
+            ctx.replyBlocking(REPLY_SERVER_ERROR + "(" + e.getStatusCode().toString() + ")");
             return;
         }
 
         if (specConsumer == null) {
-            ctx.reply("No definition found for " + word + ".");
+            ctx.replyBlocking("No definition found for " + word + ".");
         } else {
             ctx.getChannel().createEmbed(specConsumer).block();
         }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleIsUp.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleIsUp.java
@@ -21,20 +21,20 @@ public final class ModuleIsUp extends Module {
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
         if (ctx.getArgs().isEmpty()) {
-            ctx.reply("Please specify a host or IP.");
+            ctx.replyBlocking("Please specify a host or IP.");
         }
 
         try {
             final InetAddress address = InetAddress.getByName(ctx.getArgs().get(0));
             if (address.isReachable(10000)) {
-                ctx.reply("Host is up!");
+                ctx.replyBlocking("Host is up!");
             } else {
-                ctx.reply("Host is down!");
+                ctx.replyBlocking("Host is down!");
             }
         } catch (UnknownHostException e) {
-            ctx.reply("Could not resolve host");
+            ctx.replyBlocking("Could not resolve host");
         } catch (IOException e) {
-            ctx.reply("Host is down!");
+            ctx.replyBlocking("Host is down!");
         }
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModulePing.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModulePing.java
@@ -17,6 +17,6 @@ public final class ModulePing extends Module {
 
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
-        ctx.reply("Pong!");
+        ctx.replyBlocking("Pong!");
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleRandomUser.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleRandomUser.java
@@ -65,7 +65,7 @@ public final class ModuleRandomUser extends Module {
 
         if (users != null && !users.isEmpty()) {
             User randomPick = users.get(RNG.nextInt(users.size()));
-            ctx.reply("The random user is " + randomPick.getUsername());
-        } else ctx.reply("There are no users to pick from");
+            ctx.replyBlocking("The random user is " + randomPick.getUsername());
+        } else ctx.replyBlocking("There are no users to pick from");
     }
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleScreenshare.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleScreenshare.java
@@ -27,11 +27,11 @@ public final class ModuleScreenshare extends Module {
                 .defaultIfEmpty(Optional.empty())
                 .subscribe(opt -> {
                     if (opt.isEmpty()) {
-                        ctx.reply(REPLY_NO_VOICE_CHANNEL);
+                        ctx.replyBlocking(REPLY_NO_VOICE_CHANNEL);
                         return;
                     }
 
-                    ctx.reply("https://discordapp.com/channels/" +
+                    ctx.replyBlocking("https://discordapp.com/channels/" +
                             ctx.getGuild().getId().asString() +
                             "/" +
                             opt.get().asString());

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleTranslate.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleTranslate.java
@@ -70,7 +70,7 @@ public final class ModuleTranslate extends Module {
     @Override
     public void invoke(@NotNull CommandContext ctx) {
         if (StringUtils.isBlank(API_URL) || StringUtils.isBlank(API_KEY)) {
-            ctx.reply(REPLY_UNCONFIGURED);
+            ctx.replyBlocking(REPLY_UNCONFIGURED);
             return;
         }
 

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleUptime.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/utility/ModuleUptime.java
@@ -18,6 +18,6 @@ public final class ModuleUptime extends Module {
 
     @Override
     public void invoke(@NotNull final CommandContext ctx) {
-        ctx.reply(References.uptime());
+        ctx.replyBlocking(References.uptime());
     }
 }

--- a/src/test/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWikipediaTest.java
+++ b/src/test/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWikipediaTest.java
@@ -8,15 +8,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.function.Consumer;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ModuleWikipediaTest {
     WireMockServer wireMockServer;
@@ -74,7 +79,7 @@ public class ModuleWikipediaTest {
         wikiModule.invoke(mockContext);
 
         ArgumentCaptor<String> reply = ArgumentCaptor.forClass(String.class);
-        verify(mockContext).reply(reply.capture());
+        verify(mockContext).replyBlocking(reply.capture());
         assertEquals("Did you mean \"aztecs\"?", reply.getValue());
 
 

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,2 @@
+# Set JDK version for Heroku
+java.runtime.version=11


### PR DESCRIPTION
# Changelist
- Split `CommandContext#reply` and sister methods into blocking and non-blocking variants
- Make typing indicator optional via `ModuleInfo.Builder#showTypingIndicator`
- Heroku deployment support (`system.properties`, environment var config, `Procfile`)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adds or revises project documentation)

## Local configuration:
- OS: Windows 10 1903, x64
- JDK: AdoptOpenJDK 11.0.5+10
