### PR TITLE
External persistence support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation group: 'org.tinylog', name: 'slf4j-binding', version: '1.3.6'
     implementation group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
     implementation group: 'com.h2database', name: 'h2', version: '1.4.199'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.9'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'

--- a/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
+++ b/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
@@ -14,10 +14,6 @@ public interface GhostConfig extends Config, Accessible, Mutable, Reloadable {
     @Key("ghost.token")
     String token();
 
-    @Key("ghost.operator-id")
-    @DefaultValue("-1")
-    Long operatorId();
-
     @Key("ghost.keys.w2g-api-key")
     @DefaultValue("ujww234232ewegwgwef4d")
     String w2gApiKey();

--- a/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
+++ b/src/main/java/com/github/coleb1911/ghost2/GhostConfig.java
@@ -14,11 +14,11 @@ public interface GhostConfig extends Config, Accessible, Mutable, Reloadable {
     @Key("ghost.token")
     String token();
 
-    @Key("ghost.operatorid")
+    @Key("ghost.operator-id")
     @DefaultValue("-1")
     Long operatorId();
 
-    @Key("ghost.w2g_api_key")
+    @Key("ghost.keys.w2g-api-key")
     @DefaultValue("ujww234232ewegwgwef4d")
-    String w2g_api_key();
+    String w2gApiKey();
 }

--- a/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/CommandDispatcher.java
@@ -1,13 +1,13 @@
 package com.github.coleb1911.ghost2.commands;
 
 import com.github.coleb1911.ghost2.Ghost2Application;
-import com.github.coleb1911.ghost2.References;
 import com.github.coleb1911.ghost2.commands.meta.CommandContext;
 import com.github.coleb1911.ghost2.commands.meta.CommandType;
 import com.github.coleb1911.ghost2.commands.meta.Module;
 import com.github.coleb1911.ghost2.commands.meta.ReflectiveAccess;
 import com.github.coleb1911.ghost2.commands.modules.operator.ModuleClaimOperator;
 import com.github.coleb1911.ghost2.database.entities.GuildMeta;
+import com.github.coleb1911.ghost2.database.repos.ApplicationMetaRepository;
 import com.github.coleb1911.ghost2.database.repos.GuildMetaRepository;
 import discord4j.core.event.domain.message.MessageCreateEvent;
 import discord4j.core.object.util.Permission;
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 public final class CommandDispatcher {
     private final ExecutorService executor;
     private final GuildMetaRepository guildRepo;
+    private final ApplicationMetaRepository amRepo;
     private final CommandRegistry registry;
 
     /**
@@ -36,8 +37,9 @@ public final class CommandDispatcher {
      */
     @Autowired
     @ReflectiveAccess
-    public CommandDispatcher(GuildMetaRepository guildRepo, CommandRegistry registry) {
+    public CommandDispatcher(GuildMetaRepository guildRepo, ApplicationMetaRepository amRepo, CommandRegistry registry) {
         this.guildRepo = guildRepo;
+        this.amRepo = amRepo;
         this.registry = registry;
 
         // Initialize command registry and thread pool
@@ -118,7 +120,7 @@ public final class CommandDispatcher {
         // An exception is made for ModuleClaimOperator
         if (!(module instanceof ModuleClaimOperator) &&
                 (module.getInfo().getType() == CommandType.OPERATOR) &&
-                (ctx.getInvoker().getId().asLong() != References.getConfig().operatorId())) {
+                (ctx.getInvoker().getId().asLong() != amRepo.getOperatorId())) {
 
             ctx.replyBlocking(Module.REPLY_INSUFFICIENT_PERMISSIONS_USER);
             return false;

--- a/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWatch2gether.java
+++ b/src/main/java/com/github/coleb1911/ghost2/commands/modules/fun/ModuleWatch2gether.java
@@ -60,7 +60,7 @@ public final class ModuleWatch2gether extends Module {
         private String url = "";
 
         @JsonProperty("api_key")
-        private String apiKey = References.getConfig().w2g_api_key();
+        private String apiKey = References.getConfig().w2gApiKey();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/github/coleb1911/ghost2/database/entities/ApplicationMeta.java
+++ b/src/main/java/com/github/coleb1911/ghost2/database/entities/ApplicationMeta.java
@@ -1,0 +1,33 @@
+package com.github.coleb1911.ghost2.database.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "APPLICATION_META")
+public class ApplicationMeta {
+    @Id
+    @Column(name = "KEY", unique = true, nullable = false)
+    private String key = "ghost2";
+
+    @Column(name = "OPERATOR_ID", unique = true)
+    private Long operatorId = -1L;
+
+    public ApplicationMeta() {
+    }
+
+    public ApplicationMeta(long operatorId) {
+        this.key = "ghost2";
+        this.operatorId = operatorId;
+    }
+
+    public void setOperatorId(Long operatorId) {
+        this.operatorId = operatorId;
+    }
+
+    public Long getOperatorId() {
+        return operatorId;
+    }
+}

--- a/src/main/java/com/github/coleb1911/ghost2/database/repos/ApplicationMetaRepository.java
+++ b/src/main/java/com/github/coleb1911/ghost2/database/repos/ApplicationMetaRepository.java
@@ -1,0 +1,23 @@
+package com.github.coleb1911.ghost2.database.repos;
+
+import com.github.coleb1911.ghost2.database.entities.ApplicationMeta;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.lang.NonNull;
+
+import java.util.Optional;
+
+public interface ApplicationMetaRepository extends CrudRepository<ApplicationMeta, String> {
+    @Override
+    @NonNull
+    <S extends ApplicationMeta> S save(@NonNull S entity);
+
+    @Override
+    @NonNull
+    Optional<ApplicationMeta> findById(@NonNull String s);
+
+    default long getOperatorId() {
+        Optional<ApplicationMeta> meta = findById("ghost2");
+        if (meta.isEmpty()) return -1;
+        return meta.get().getOperatorId();
+    }
+}

--- a/src/main/java/com/github/coleb1911/ghost2/database/repos/GuildMetaRepository.java
+++ b/src/main/java/com/github/coleb1911/ghost2/database/repos/GuildMetaRepository.java
@@ -2,10 +2,8 @@ package com.github.coleb1911.ghost2.database.repos;
 
 import com.github.coleb1911.ghost2.commands.meta.ReflectiveAccess;
 import com.github.coleb1911.ghost2.database.entities.GuildMeta;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
@@ -16,23 +14,23 @@ import java.util.Optional;
 @Component
 public interface GuildMetaRepository extends CrudRepository<GuildMeta, Long> {
     @Override
-    @CachePut("guilds")
-    <S extends GuildMeta> S save(S entity);
+    @NonNull
+    <S extends GuildMeta> S save(@NonNull S entity);
 
     @Override
-    @Cacheable(value = "guilds", key = "#p0")
-    Optional<GuildMeta> findById(Long id);
+    @NonNull
+    Optional<GuildMeta> findById(@NonNull Long id);
 
     @Override
+    @NonNull
     Iterable<GuildMeta> findAll();
 
     @Override
     long count();
 
     @Override
-    @CacheEvict(value = "guilds", key = "#p0.id")
-    void delete(GuildMeta guild);
+    void delete(@NonNull GuildMeta guild);
 
     @Override
-    boolean existsById(Long id);
+    boolean existsById(@NonNull Long id);
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,14 +2,17 @@ open module ghost2.main {
     requires java.annotation;
     requires java.validation;
     requires java.persistence;
-    requires spring.web;
+    requires java.sql;
     requires spring.core;
+    requires spring.web;
+    requires spring.orm;
     requires spring.boot;
     requires spring.beans;
     requires spring.context;
     requires spring.data.jpa;
     requires spring.data.commons;
     requires spring.boot.autoconfigure;
+    requires com.zaxxer.hikari;
     requires org.apache.commons.lang3;
     requires org.apache.httpcomponents.httpclient;
     requires org.apache.httpcomponents.httpcore;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,8 @@
-# Do not touch. This file defines crucial settings for Spring/Hibernate DDL.
-# suppress inspection "UnusedProperty" for whole file
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.driverClassName=org.h2.Driver
+## Do not touch. This file defines crucial settings for Spring/Hibernate DDL.
+## suppress inspection "UnusedProperty" for whole file
 spring.datasource.url=jdbc:h2:./ghost
 spring.datasource.username=ghost
 spring.datasource.password=ghost
-
+spring.jpa.hibernate.ddl-auto=update
 #Workaround to prevent embedded Apache Tomcat from starting
 spring.main.web-application-type=none


### PR DESCRIPTION
# Changelist
- Small change to Spring application properties to support externalized persistence solutions
- Migrate `ghost.operator-id` to new `APPLICATION_META` table to avoid dependence on `ghost.properties` in instances configured via environment vars
- ...subsequently, fix NPE in `ModuleClaimOperator` when `ghost.properties` is not present

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adds or revises project documentation)

## Local configuration:
- OS: Windows 10 1903, x64
- JDK: AdoptOpenJDK 11.0.6+10